### PR TITLE
Make HDR histogram latency cap configurable (--max-latency-seconds, default 1s)

### DIFF
--- a/benchmark_runner/benchmark_runner.go
+++ b/benchmark_runner/benchmark_runner.go
@@ -266,9 +266,10 @@ func (b *BenchmarkRunner) GetPerSecondEncodedHistogramsMap() map[uint64]string {
 }
 
 // defaultMaxLatencySeconds is the default upper bound for HDR histogram
-// tracking. Disk-backed RediSearch tail latencies routinely exceed 1s, so the
-// default is set high enough to avoid silently capping them.
-const defaultMaxLatencySeconds = 60
+// tracking. Kept at 1s for backwards compatibility with existing dashboards
+// and report consumers; raise via --max-latency-seconds (e.g. 60) when the
+// workload's tail exceeds 1s, as is common on disk-backed RediSearch.
+const defaultMaxLatencySeconds = 1
 
 // Histograms are allocated in initHistograms once flags have been parsed and
 // the configured cap is known.
@@ -337,8 +338,9 @@ func GetBenchmarkRunnerWithBatchSize(batchSize uint) *BenchmarkRunner {
 	flag.UintVar(&loader.maxTokenSizeMB, "max-token-size-mb", 1, "Maximum size of token to read from input file in MB. Minimum is 1MB.")
 	flag.UintVar(&loader.batchSize, "batch-size", batchSize, "Number of items to batch together per worker channel before dispatch.")
 	flag.Int64Var(&loader.maxLatencySeconds, "max-latency-seconds", defaultMaxLatencySeconds,
-		"Upper bound (in seconds) for HDR histogram latency tracking. Latencies above this cap are clamped. "+
-			"Larger values use more memory per histogram (each histogram is allocated 14 fixed times plus once per query type and once per benchmark second).")
+		"Upper bound (in seconds) for HDR histogram latency tracking. Samples above this cap are dropped (not recorded). "+
+			"Default is 1s for backwards compatibility; raise (e.g. 60) when tail latencies exceed 1s, as on disk-backed RediSearch. "+
+			"Larger values use more memory per histogram (one fixed histogram per phase, plus one per query type and one per benchmark second).")
 	return loader
 }
 

--- a/benchmark_runner/benchmark_runner.go
+++ b/benchmark_runner/benchmark_runner.go
@@ -62,6 +62,11 @@ type BenchmarkRunner struct {
 	totalErrors   uint64
 	totalTimeouts uint64
 
+	// maxLatencySeconds caps the highest trackable latency for every HDR
+	// histogram. Configurable via --max-latency-seconds. Converted to µs at
+	// histogram-allocation time.
+	maxLatencySeconds int64
+
 	br                         *bufio.Reader
 	detailedMapHistogramsMutex sync.RWMutex
 	detailedMapHistograms      map[string]*hdrhistogram.Histogram
@@ -260,30 +265,54 @@ func (b *BenchmarkRunner) GetPerSecondEncodedHistogramsMap() map[uint64]string {
 	return configs
 }
 
+// defaultMaxLatencySeconds is the default upper bound for HDR histogram
+// tracking. Disk-backed RediSearch tail latencies routinely exceed 1s, so the
+// default is set high enough to avoid silently capping them.
+const defaultMaxLatencySeconds = 60
+
+// Histograms are allocated in initHistograms once flags have been parsed and
+// the configured cap is known.
 var loader = &BenchmarkRunner{
-	setupWriteHistogram:      hdrhistogram.New(1, 1000000, 3),
-	inst_setupWriteHistogram: hdrhistogram.New(1, 1000000, 3),
-	setupWriteTs:             make([]DataPoint, 0, 10),
-	writeHistogram:           hdrhistogram.New(1, 1000000, 3),
-	inst_writeHistogram:      hdrhistogram.New(1, 1000000, 3),
-	writeTs:                  make([]DataPoint, 0, 10),
-	updateHistogram:          hdrhistogram.New(1, 1000000, 3),
-	inst_updateHistogram:     hdrhistogram.New(1, 1000000, 3),
-	updateTs:                 make([]DataPoint, 0, 10),
-	readHistogram:            hdrhistogram.New(1, 1000000, 3),
-	inst_readHistogram:       hdrhistogram.New(1, 1000000, 3),
-	readTs:                   make([]DataPoint, 0, 10),
-	readCursorHistogram:      hdrhistogram.New(1, 1000000, 3),
-	inst_readCursorHistogram: hdrhistogram.New(1, 1000000, 3),
-	readCursorTs:             make([]DataPoint, 0, 10),
-	deleteHistogram:          hdrhistogram.New(1, 1000000, 3),
-	inst_deleteHistogram:     hdrhistogram.New(1, 1000000, 3),
-	deleteTs:                 make([]DataPoint, 0, 10),
-	totalHistogram:           hdrhistogram.New(1, 1000000, 3),
-	inst_totalHistogram:      hdrhistogram.New(1, 1000000, 3),
-	totalTs:                  make([]DataPoint, 0, 10),
-	detailedMapHistograms:    make(map[string]*hdrhistogram.Histogram),
-	perSecondHistograms:      make(map[uint64]*hdrhistogram.Histogram),
+	setupWriteTs:          make([]DataPoint, 0, 10),
+	writeTs:               make([]DataPoint, 0, 10),
+	updateTs:              make([]DataPoint, 0, 10),
+	readTs:                make([]DataPoint, 0, 10),
+	readCursorTs:          make([]DataPoint, 0, 10),
+	deleteTs:              make([]DataPoint, 0, 10),
+	totalTs:               make([]DataPoint, 0, 10),
+	detailedMapHistograms: make(map[string]*hdrhistogram.Histogram),
+	perSecondHistograms:   make(map[uint64]*hdrhistogram.Histogram),
+}
+
+// maxLatencyMicros returns the configured cap in microseconds. Falls back to
+// the default when the flag was not registered (e.g., direct programmatic use).
+func (l *BenchmarkRunner) maxLatencyMicros() int64 {
+	secs := l.maxLatencySeconds
+	if secs <= 0 {
+		secs = defaultMaxLatencySeconds
+	}
+	return secs * 1_000_000
+}
+
+// initHistograms allocates the fixed phase histograms using the configured
+// max latency cap. Must be called after flag.Parse and before any worker
+// records into a histogram.
+func (l *BenchmarkRunner) initHistograms() {
+	cap := l.maxLatencyMicros()
+	l.setupWriteHistogram = hdrhistogram.New(1, cap, 3)
+	l.inst_setupWriteHistogram = hdrhistogram.New(1, cap, 3)
+	l.writeHistogram = hdrhistogram.New(1, cap, 3)
+	l.inst_writeHistogram = hdrhistogram.New(1, cap, 3)
+	l.updateHistogram = hdrhistogram.New(1, cap, 3)
+	l.inst_updateHistogram = hdrhistogram.New(1, cap, 3)
+	l.readHistogram = hdrhistogram.New(1, cap, 3)
+	l.inst_readHistogram = hdrhistogram.New(1, cap, 3)
+	l.readCursorHistogram = hdrhistogram.New(1, cap, 3)
+	l.inst_readCursorHistogram = hdrhistogram.New(1, cap, 3)
+	l.deleteHistogram = hdrhistogram.New(1, cap, 3)
+	l.inst_deleteHistogram = hdrhistogram.New(1, cap, 3)
+	l.totalHistogram = hdrhistogram.New(1, cap, 3)
+	l.inst_totalHistogram = hdrhistogram.New(1, cap, 3)
 }
 
 // GetBenchmarkRunner returns the singleton BenchmarkRunner for use in a benchmark program
@@ -307,6 +336,9 @@ func GetBenchmarkRunnerWithBatchSize(batchSize uint) *BenchmarkRunner {
 	flag.StringVar(&loader.Metadata, "metadata-string", "", "Metadata string to add to json-out-file. If -json-out-file is not set, will not use this option.")
 	flag.UintVar(&loader.maxTokenSizeMB, "max-token-size-mb", 1, "Maximum size of token to read from input file in MB. Minimum is 1MB.")
 	flag.UintVar(&loader.batchSize, "batch-size", batchSize, "Number of items to batch together per worker channel before dispatch.")
+	flag.Int64Var(&loader.maxLatencySeconds, "max-latency-seconds", defaultMaxLatencySeconds,
+		"Upper bound (in seconds) for HDR histogram latency tracking. Latencies above this cap are clamped. "+
+			"Larger values use more memory per histogram (each histogram is allocated 14 fixed times plus once per query type and once per benchmark second).")
 	return loader
 }
 
@@ -314,6 +346,7 @@ func GetBenchmarkRunnerWithBatchSize(batchSize uint) *BenchmarkRunner {
 // and reads those to run the benchmark benchmark
 func (l *BenchmarkRunner) RunBenchmark(b Benchmark, workQueues uint) {
 	l.br = l.GetBufferedReader()
+	l.initHistograms()
 
 	channels := l.createChannels(workQueues)
 	// Launch all worker processes in background
@@ -490,7 +523,7 @@ func (l *BenchmarkRunner) work(b Benchmark, wg *sync.WaitGroup, c *duplexChannel
 			groupAndQuery := labelStr + "-" + querystr
 			l.detailedMapHistogramsMutex.Lock()
 			if _, exist := l.detailedMapHistograms[groupAndQuery]; !exist {
-				l.detailedMapHistograms[groupAndQuery] = hdrhistogram.New(1, 1000000, 3)
+				l.detailedMapHistograms[groupAndQuery] = hdrhistogram.New(1, l.maxLatencyMicros(), 3)
 			}
 			l.detailedMapHistograms[groupAndQuery].RecordValue(int64(cmdStat.Latency()))
 			l.detailedMapHistogramsMutex.Unlock()
@@ -498,7 +531,7 @@ func (l *BenchmarkRunner) work(b Benchmark, wg *sync.WaitGroup, c *duplexChannel
 			ts := cmdStat.StartTs()
 			l.perSecondHistogramsMutex.Lock()
 			if _, exist := l.perSecondHistograms[ts]; !exist {
-				l.perSecondHistograms[ts] = hdrhistogram.New(1, 1000000, 3)
+				l.perSecondHistograms[ts] = hdrhistogram.New(1, l.maxLatencyMicros(), 3)
 			}
 			l.perSecondHistograms[ts].RecordValue(int64(cmdStat.Latency()))
 			l.perSecondHistogramsMutex.Unlock()

--- a/benchmark_runner/redisearch_test.go
+++ b/benchmark_runner/redisearch_test.go
@@ -270,7 +270,11 @@ func TestFTSBWithConnectionFailure(t *testing.T) {
 	}
 }
 
-func TestFTSBWithTimeout(t *testing.T) {
+// startRedisDebugContainer spins up redis:8.6-rc1 with --enable-debug-command
+// on host port 6379 and registers cleanup. Centralised so duplicated docker
+// boilerplate doesn't flake the SonarCloud duplication gate.
+func startRedisDebugContainer(t *testing.T) {
+	t.Helper()
 	t.Log("Starting Redis container with debug commands enabled...")
 	dockerRun := exec.Command("docker", "run", "--rm", "-d", "-p", "6379:6379",
 		"redis:8.6-rc1", "redis-server", "--enable-debug-command", "yes")
@@ -283,9 +287,12 @@ func TestFTSBWithTimeout(t *testing.T) {
 		t.Log("Stopping Redis container...")
 		exec.Command("docker", "stop", containerID).Run()
 	})
-
 	t.Log("Waiting for Redis to be ready...")
 	time.Sleep(2 * time.Second)
+}
+
+func TestFTSBWithTimeout(t *testing.T) {
+	startRedisDebugContainer(t)
 
 	t.Log("Running ftsb_redisearch with timeout_test.csv (contains DEBUG SLEEP commands)")
 	jsonPath := "../testdata/results.timeout.json"
@@ -471,21 +478,7 @@ func TestFTSBWithLogFile(t *testing.T) {
 }
 
 func TestFTSBWithLogFileAndTimeout(t *testing.T) {
-	t.Log("Starting Redis container with debug commands enabled...")
-	dockerRun := exec.Command("docker", "run", "--rm", "-d", "-p", "6379:6379",
-		"redis:8.6-rc1", "redis-server", "--enable-debug-command", "yes")
-	containerIDRaw, err := dockerRun.Output()
-	if err != nil {
-		t.Fatalf("Failed to start Redis container: %v", err)
-	}
-	containerID := strings.TrimSpace(string(containerIDRaw))
-	t.Cleanup(func() {
-		t.Log("Stopping Redis container...")
-		exec.Command("docker", "stop", containerID).Run()
-	})
-
-	t.Log("Waiting for Redis to be ready...")
-	time.Sleep(2 * time.Second)
+	startRedisDebugContainer(t)
 
 	t.Log("Running ftsb_redisearch with timeout_test.csv and --log-file")
 	logPath := "../testdata/benchmark_timeout.log"
@@ -607,21 +600,7 @@ func TestFTSBWithBatchSize(t *testing.T) {
 // --max-latency-seconds (and anything else).
 func runSleepBenchmark(t *testing.T, jsonPath string, extraArgs ...string) float64 {
 	t.Helper()
-	t.Log("Starting Redis container with debug commands enabled...")
-	dockerRun := exec.Command("docker", "run", "--rm", "-d", "-p", "6379:6379",
-		"redis:8.6-rc1", "redis-server", "--enable-debug-command", "yes")
-	containerIDRaw, err := dockerRun.Output()
-	if err != nil {
-		t.Fatalf("Failed to start Redis container: %v", err)
-	}
-	containerID := strings.TrimSpace(string(containerIDRaw))
-	t.Cleanup(func() {
-		t.Log("Stopping Redis container...")
-		exec.Command("docker", "stop", containerID).Run()
-	})
-
-	t.Log("Waiting for Redis to be ready...")
-	time.Sleep(2 * time.Second)
+	startRedisDebugContainer(t)
 
 	args := []string{
 		"--input", "../testdata/sleep_test.csv",

--- a/benchmark_runner/redisearch_test.go
+++ b/benchmark_runner/redisearch_test.go
@@ -651,30 +651,27 @@ func runSleepBenchmark(t *testing.T, jsonPath string, extraArgs ...string) float
 	return q100
 }
 
-// TestFTSBLatencyCapDefault verifies that with the new 60s default cap, a
-// DEBUG SLEEP 2 latency is recorded above the old 1s ceiling. Prior to the
-// configurable cap, this would have clamped at ~1000 ms.
-func TestFTSBLatencyCapDefault(t *testing.T) {
+// TestFTSBLatencyCapDefaultDropsAboveOneSecond locks in the backwards-
+// compatible default: with the flag unset, the 1s cap drops a 2s DEBUG SLEEP
+// sample (hdrhistogram.RecordValue rejects values above highestTrackable).
+// q100 falls back to the sub-millisecond SET commands.
+func TestFTSBLatencyCapDefaultDropsAboveOneSecond(t *testing.T) {
 	q100 := runSleepBenchmark(t, "../testdata/results.latencycap_default.json")
-	if q100 <= 1000 {
-		t.Errorf("Expected q100 > 1000 ms with default 60s cap (DEBUG SLEEP 2 should record ~2000 ms), got %.2f ms", q100)
-	}
-	if q100 < 1500 {
-		t.Errorf("Expected q100 >= 1500 ms (DEBUG SLEEP 2), got %.2f ms — sleep may not have run", q100)
+	if q100 > 1100 {
+		t.Errorf("Expected q100 <= ~1000 ms with default 1s cap (DEBUG SLEEP 2 should be dropped), got %.2f ms", q100)
 	}
 }
 
-// TestFTSBLatencyCapClamped verifies that --max-latency-seconds=1 actually
-// clamps recorded latencies — proving the flag is wired through to every
-// histogram allocation site (fixed + per-second + per-query).
-func TestFTSBLatencyCapClamped(t *testing.T) {
+// TestFTSBLatencyCapHighOptIn verifies that --max-latency-seconds=60 lifts
+// the cap so a DEBUG SLEEP 2 latency is actually recorded. Proves the flag
+// is wired through to every histogram allocation site (fixed + per-query +
+// per-second).
+func TestFTSBLatencyCapHighOptIn(t *testing.T) {
 	q100 := runSleepBenchmark(t,
-		"../testdata/results.latencycap_clamped.json",
-		"--max-latency-seconds=1",
+		"../testdata/results.latencycap_high.json",
+		"--max-latency-seconds=60",
 	)
-	// hdrhistogram clamps RecordValue to highestTrackable; with cap=1s we
-	// expect q100 <= ~1000 ms even though the real latency was ~2000 ms.
-	if q100 > 1100 {
-		t.Errorf("Expected q100 <= ~1000 ms when capped at 1s, got %.2f ms — flag not honored", q100)
+	if q100 < 1500 {
+		t.Errorf("Expected q100 >= 1500 ms with --max-latency-seconds=60 (DEBUG SLEEP 2 should record ~2000 ms), got %.2f ms", q100)
 	}
 }

--- a/benchmark_runner/redisearch_test.go
+++ b/benchmark_runner/redisearch_test.go
@@ -599,3 +599,103 @@ func TestFTSBWithBatchSize(t *testing.T) {
 		t.Errorf("Expected benchmark output to contain 'Issued', got: %s", outputStr)
 	}
 }
+
+// runSleepBenchmark spins up a Redis container with debug commands enabled,
+// runs ftsb_redisearch against testdata/sleep_test.csv (which contains a
+// DEBUG SLEEP 2), and returns the q100 (max) latency in milliseconds for the
+// "allCommands" group in the JSON output. extraArgs lets the caller override
+// --max-latency-seconds (and anything else).
+func runSleepBenchmark(t *testing.T, jsonPath string, extraArgs ...string) float64 {
+	t.Helper()
+	t.Log("Starting Redis container with debug commands enabled...")
+	dockerRun := exec.Command("docker", "run", "--rm", "-d", "-p", "6379:6379",
+		"redis:8.6-rc1", "redis-server", "--enable-debug-command", "yes")
+	containerIDRaw, err := dockerRun.Output()
+	if err != nil {
+		t.Fatalf("Failed to start Redis container: %v", err)
+	}
+	containerID := strings.TrimSpace(string(containerIDRaw))
+	t.Cleanup(func() {
+		t.Log("Stopping Redis container...")
+		exec.Command("docker", "stop", containerID).Run()
+	})
+
+	t.Log("Waiting for Redis to be ready...")
+	time.Sleep(2 * time.Second)
+
+	args := []string{
+		"--input", "../testdata/sleep_test.csv",
+		"--workers=1",
+		"--timeout=10", // seconds; well above the 2s sleep so the request completes
+		"--json-out-file", jsonPath,
+	}
+	args = append(args, extraArgs...)
+
+	t.Logf("Running ftsb_redisearch %v", args)
+	cmd := exec.Command("../bin/ftsb_redisearch", args...)
+	cmd.Env = append(os.Environ(), "REDIS_URL=redis://localhost:6379")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Benchmark failed: %v\nOutput: %s", err, string(output))
+	}
+
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("Failed to read json output file: %v", err)
+	}
+
+	var parsed struct {
+		OverallQuantiles struct {
+			AllCommands map[string]float64 `json:"allCommands"`
+		} `json:"OverallQuantiles"`
+		Totals struct {
+			TotalOps int     `json:"TotalOps"`
+			Timeouts float64 `json:"Timeouts"`
+		} `json:"Totals"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v", err)
+	}
+
+	if parsed.Totals.Timeouts > 0 {
+		t.Fatalf("DEBUG SLEEP unexpectedly timed out (%v); raise --timeout in the test setup", parsed.Totals.Timeouts)
+	}
+	if parsed.Totals.TotalOps <= 0 {
+		t.Fatalf("Expected TotalOps > 0, got %v", parsed.Totals.TotalOps)
+	}
+
+	q100, ok := parsed.OverallQuantiles.AllCommands["q100"]
+	if !ok {
+		t.Fatalf("Expected OverallQuantiles.allCommands.q100 in JSON, got: %s", string(data))
+	}
+	t.Logf("q100 (max latency) = %.2f ms", q100)
+	return q100
+}
+
+// TestFTSBLatencyCapDefault verifies that with the new 60s default cap, a
+// DEBUG SLEEP 2 latency is recorded above the old 1s ceiling. Prior to the
+// configurable cap, this would have clamped at ~1000 ms.
+func TestFTSBLatencyCapDefault(t *testing.T) {
+	q100 := runSleepBenchmark(t, "../testdata/results.latencycap_default.json")
+	if q100 <= 1000 {
+		t.Errorf("Expected q100 > 1000 ms with default 60s cap (DEBUG SLEEP 2 should record ~2000 ms), got %.2f ms", q100)
+	}
+	if q100 < 1500 {
+		t.Errorf("Expected q100 >= 1500 ms (DEBUG SLEEP 2), got %.2f ms — sleep may not have run", q100)
+	}
+}
+
+// TestFTSBLatencyCapClamped verifies that --max-latency-seconds=1 actually
+// clamps recorded latencies — proving the flag is wired through to every
+// histogram allocation site (fixed + per-second + per-query).
+func TestFTSBLatencyCapClamped(t *testing.T) {
+	q100 := runSleepBenchmark(t,
+		"../testdata/results.latencycap_clamped.json",
+		"--max-latency-seconds=1",
+	)
+	// hdrhistogram clamps RecordValue to highestTrackable; with cap=1s we
+	// expect q100 <= ~1000 ms even though the real latency was ~2000 ms.
+	if q100 > 1100 {
+		t.Errorf("Expected q100 <= ~1000 ms when capped at 1s, got %.2f ms — flag not honored", q100)
+	}
+}

--- a/testdata/sleep_test.csv
+++ b/testdata/sleep_test.csv
@@ -1,0 +1,3 @@
+"WRITE","W1",1,"SET","key1","value1"
+"WRITE","W1",1,"DEBUG","SLEEP","2"
+"WRITE","W1",1,"SET","key2","value2"


### PR DESCRIPTION
## Summary
- Hardcoded `hdrhistogram.New(1, 1_000_000, 3)` clamped every recorded latency at 1 s. RediSearch on disk-backed storage routinely sees tails above 1 s, so those samples were silently rejected by the histograms.
- Added `--max-latency-seconds` flag (default `1`, **kept at 1s for backwards compatibility** per review feedback). Disk-backed runs opt in with `--max-latency-seconds=60`.
- Moved the 14 fixed phase histograms out of the global initializer into `initHistograms()`, called from `RunBenchmark` after `flag.Parse`. Two dynamic maps (`detailedMapHistograms`, `perSecondHistograms`) now also use the configured cap.

## Memory impact (sigDigits=3)
| Cap | bucketCount | bytes / histogram |
|---|---|---|
| 1 s (default, unchanged) | 10 | ~88 KiB |
| 60 s (opt-in) | 16 | ~136 KiB |

At opt-in, per-histogram delta is ~48 KiB (+54%). For a 1 h run with 30 query types, total histogram memory grows from ~313 MiB to ~484 MiB — comfortably within bench-client EC2 RAM. Dominant cost is the per-second map.

## Tests
- `TestFTSBLatencyCapDefaultDropsAboveOneSecond` — runs `DEBUG SLEEP 2` against Redis with default 1s cap; asserts `q100 <= ~1000 ms` (the SLEEP record is dropped, locking in BC).
- `TestFTSBLatencyCapHighOptIn` — runs the same workload with `--max-latency-seconds=60`; asserts `q100 >= 1500 ms`, proving the flag is wired through every histogram allocation site.

Both validated locally against `redis:8.6-rc1 --enable-debug-command yes`:
- default 1s → `q100 = 0.149 ms`, `TotalOps = 2` (SLEEP rejected)
- `--max-latency-seconds=60` → `q100 = 2000.895 ms`, `TotalOps = 3` (SLEEP recorded)

Also dedupes the docker setup boilerplate via `startRedisDebugContainer` (used by the new tests + two existing tests).

## Test plan
- [x] CI integration tests pass (existing TestFTSBWith* + new latency-cap tests)
- [x] Manual: `--help` shows `(default 1)` for `--max-latency-seconds`