### PR TITLE
Support base64-encoded binary command arguments (__b64__ marker) [MOD-16439]

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,5 +24,8 @@ jobs:
         with:
           go-version: '1.21'
 
+      - name: Run unit tests
+        run: make unit-test
+
       - name: Run integration tests
         run: make integration-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # FTSB outputs #
 ################
-ftsb_redisearch
-cmd/ftsb_redisearch/ftsb_redisearch
+# Root-anchored so these match the built BINARIES only, not the
+# cmd/ftsb_redisearch/ source directory (an unanchored `ftsb_redisearch`
+# silently ignored new source files under cmd/ftsb_redisearch/).
+/ftsb_redisearch
+/cmd/ftsb_redisearch/ftsb_redisearch
 
 ###################
 # Data generators #

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ get:
 integration-test: get ftsb_redisearch
 	$(GOTEST) -v $(shell go list ./... | grep -v '/cmd/')
 
+# unit-test runs the pure-Go tests for the cmd packages, which integration-test
+# excludes. These need no Redis, so they run standalone with the race detector.
+unit-test: get
+	$(GOTEST) -v -race ./cmd/...
+
 release:
 	@mkdir -p ${DISTDIR}
 	@for pair in $(OS_ARCHs); do \

--- a/README.md
+++ b/README.md
@@ -110,6 +110,34 @@ which will translate to the following command being issued:
 ```
 FT.ADD idx doc1 1.0 FIELDS title "hello world"
 ```
+
+#### Binary / vector arguments (`__b64__` marker)
+
+Raw binary values (e.g. a little-endian `float32` blob for a `VECTOR` field)
+cannot travel inside this line-oriented CSV format, because a blob may contain
+`0x0A` (newline) bytes that break the line scanner, and storing base64 verbatim
+is rejected by RediSearch on ingest (blob-size mismatch).
+
+To carry binary data, prefix the affected argument value with `__b64__` and
+base64-encode the raw bytes using **RFC 4648 standard encoding** (the `+`/`/`
+alphabet, padded with `=` — *not* URL-safe, *not* raw/unpadded). The runner
+decodes any `__b64__`-marked argument back to its exact raw bytes right before
+the command is sent to Redis. Both ingest and query rows are decoded, so KNN
+query `BLOB` params can use the same marker.
+
+```
+SETUP,setup-doc-1,1,HSET,doc:1,vec,__b64__zczMPc3MTD6amZk+zczMPg==
+```
+executes `HSET doc:1 vec <16 raw bytes>`.
+
+Notes:
+- Unmarked arguments are untouched — existing input files are unaffected.
+- The `__b64__` prefix is **reserved**: a genuine field value that literally
+  begins with `__b64__` will be treated as a marker (there is no escape).
+- A marked argument that is not valid standard base64, or that decodes to zero
+  bytes, is treated as a corrupt row. Under `-continue-on-error` (default) the
+  row is logged and skipped; otherwise the run aborts.
+
 The following links deep dive on:
 
 - Generating inputs from pre-baked benchmark suites (ecommerce-inventory , enwiki-abstract , enwiki-pages) 

--- a/cmd/ftsb_redisearch/cmd_processor.go
+++ b/cmd/ftsb_redisearch/cmd_processor.go
@@ -167,8 +167,11 @@ func connectionProcessor(p *processor, rateLimiter *rate.Limiter, useRateLimiter
 			}
 		}
 		clusterAddrLen = len(clusterSlots)
-		// start at a random slot between 0 and clusterAddrLen
-		slotP = rand.Intn(clusterAddrLen)
+		// start at a random slot between 0 and clusterAddrLen.
+		// NOSONAR: math/rand is intentional here — this only spreads the
+		// benchmark's starting slot for load distribution; it is not security
+		// sensitive and needs no crypto-grade randomness.
+		slotP = rand.Intn(clusterAddrLen) // NOSONAR
 	}
 
 	for row := range p.rows {

--- a/cmd/ftsb_redisearch/cmd_processor.go
+++ b/cmd/ftsb_redisearch/cmd_processor.go
@@ -22,22 +22,42 @@ import (
 // (embedded newlines break the scanner), so generators emit
 // `__b64__<base64>` and the argument is decoded back to raw bytes here,
 // right before the command is sent to Redis.
+//
+// Contract: the payload after the marker MUST be RFC 4648 *standard* base64
+// (the `+`/`/` alphabet, padded with `=`). URL-safe or unpadded (raw)
+// encodings are rejected. Any value whose literal prefix is `__b64__` is
+// treated as a marker, so this token is reserved: a genuine field value that
+// begins with it cannot be represented and will be decoded (or rejected).
 const binaryArgMarker = "__b64__"
 
-// decodeBinaryArgs base64-decodes every `__b64__`-marked argument in place.
-// A marked argument that fails to decode means the input file is corrupt:
-// silently passing it through would ingest garbage into Redis, so it aborts.
-func decodeBinaryArgs(args []string) {
+// decodeBinaryArgs base64-decodes every `__b64__`-marked argument in place and
+// returns `shrink`, the total number of input bytes removed by decoding (base64
+// expands the payload ~4/3 and the 7-byte marker is stripped). The caller
+// subtracts `shrink` from its raw-row byte count so the reported wire-byte
+// throughput reflects the decoded bytes actually sent to Redis, not the larger
+// base64 text.
+//
+// A marked argument that fails to decode — or that decodes to zero bytes —
+// means the input file is corrupt: silently passing it through would ingest
+// garbage into Redis. The error is *returned* (not fatal) so the caller can
+// honor -continue-on-error, consistent with every other error path here.
+func decodeBinaryArgs(args []string) (shrink uint64, err error) {
 	for i, arg := range args {
 		if strings.HasPrefix(arg, binaryArgMarker) {
-			decoded, err := base64.StdEncoding.DecodeString(arg[len(binaryArgMarker):])
-			if err != nil {
-				log.Fatalf("failed to base64-decode binary argument at position %d: %v", i, err)
+			decoded, decErr := base64.StdEncoding.DecodeString(arg[len(binaryArgMarker):])
+			if decErr != nil {
+				// i indexes into args (argsStr[4:]); +4 gives the CSV column.
+				return 0, fmt.Errorf("failed to base64-decode binary argument at CSV field %d: %w", i+4, decErr)
 			}
+			if len(decoded) == 0 {
+				return 0, fmt.Errorf("empty base64 binary argument at CSV field %d: %q", i+4, arg)
+			}
+			shrink += uint64(len(arg) - len(decoded))
 			// Go strings carry arbitrary bytes; radix sends them verbatim.
 			args[i] = string(decoded)
 		}
 	}
+	return shrink, nil
 }
 
 type processor struct {
@@ -152,7 +172,16 @@ func connectionProcessor(p *processor, rateLimiter *rate.Limiter, useRateLimiter
 	}
 
 	for row := range p.rows {
-		cmdType, cmdQueryId, keyPos, cmd, key, clusterSlot, docFields, bytelen, _ := preProcessCmd(row)
+		cmdType, cmdQueryId, keyPos, cmd, key, clusterSlot, docFields, bytelen, err := preProcessCmd(row)
+		if err != nil {
+			// Honor -continue-on-error like every other error path: skip the
+			// bad row rather than nuking an entire (EC2-billed) benchmark run.
+			if continueOnErr {
+				log.Printf("skipping malformed row: %v", err)
+				continue
+			}
+			log.Fatalf("fatal error preprocessing row: %v", err)
+		}
 
 		if clusterSlot > -1 {
 			for i, sArr := range clusterSlots {
@@ -336,15 +365,27 @@ func preProcessCmd(row string) (cmdType string, cmdQueryId string, keyPos int, c
 		keyPos = initialPos + 3
 		cmd = argsStr[3]
 		clusterSlot = -1
+		var shrink uint64
 		if len(argsStr) > 4 {
 			args = argsStr[4:]
-			decodeBinaryArgs(args)
+			shrink, err = decodeBinaryArgs(args)
+			if err != nil {
+				return
+			}
+			// Guard the key index: a malformed row (keyPos derived from the
+			// untrusted pos field) must not panic the whole worker goroutine.
+			if keyPos < 0 || keyPos >= len(argsStr) {
+				err = fmt.Errorf("key position %d out of range for row with %d fields: %s", keyPos, len(argsStr), row)
+				return
+			}
 			key = argsStr[keyPos]
 		}
 		if initialPos >= 0 {
 			clusterSlot = int(radix.ClusterSlot([]byte(key)))
 		}
-		bytelen = uint64(len(row)) - uint64(len(cmdType))
+		// Subtract the base64 shrink so byte accounting reflects the decoded
+		// bytes actually sent to Redis, not the larger base64 text in the row.
+		bytelen = uint64(len(row)) - uint64(len(cmdType)) - shrink
 	} else {
 		err = fmt.Errorf("input string does not have the minimum required size of 2: %s", row)
 	}

--- a/cmd/ftsb_redisearch/cmd_processor.go
+++ b/cmd/ftsb_redisearch/cmd_processor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/csv"
 	"fmt"
 	"log"
@@ -14,6 +15,30 @@ import (
 	radix "github.com/mediocregopher/radix/v3"
 	"golang.org/x/time/rate"
 )
+
+// binaryArgMarker prefixes a command argument whose value is base64-encoded
+// binary data (e.g. a raw little-endian float32 vector blob for a VECTOR
+// field). Raw binary can't travel inside the line-oriented CSV input format
+// (embedded newlines break the scanner), so generators emit
+// `__b64__<base64>` and the argument is decoded back to raw bytes here,
+// right before the command is sent to Redis.
+const binaryArgMarker = "__b64__"
+
+// decodeBinaryArgs base64-decodes every `__b64__`-marked argument in place.
+// A marked argument that fails to decode means the input file is corrupt:
+// silently passing it through would ingest garbage into Redis, so it aborts.
+func decodeBinaryArgs(args []string) {
+	for i, arg := range args {
+		if strings.HasPrefix(arg, binaryArgMarker) {
+			decoded, err := base64.StdEncoding.DecodeString(arg[len(binaryArgMarker):])
+			if err != nil {
+				log.Fatalf("failed to base64-decode binary argument at position %d: %v", i, err)
+			}
+			// Go strings carry arbitrary bytes; radix sends them verbatim.
+			args[i] = string(decoded)
+		}
+	}
+}
 
 type processor struct {
 	rows           chan string
@@ -313,6 +338,7 @@ func preProcessCmd(row string) (cmdType string, cmdQueryId string, keyPos int, c
 		clusterSlot = -1
 		if len(argsStr) > 4 {
 			args = argsStr[4:]
+			decodeBinaryArgs(args)
 			key = argsStr[keyPos]
 		}
 		if initialPos >= 0 {

--- a/cmd/ftsb_redisearch/cmd_processor_test.go
+++ b/cmd/ftsb_redisearch/cmd_processor_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
+
+	radix "github.com/mediocregopher/radix/v3"
 )
 
 // A 16-byte little-endian float32 payload whose bytes include 0x0A (newline)
@@ -17,23 +20,68 @@ var rawBinary = []byte{
 
 func TestDecodeBinaryArgsDecodesMarkedArg(t *testing.T) {
 	args := []string{"doc:1", "vec", binaryArgMarker + base64.StdEncoding.EncodeToString(rawBinary)}
-	decodeBinaryArgs(args)
+	shrink, err := decodeBinaryArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if args[2] != string(rawBinary) {
 		t.Fatalf("marked arg not decoded to raw bytes: got %q", args[2])
 	}
 	if len(args[2]) != len(rawBinary) {
 		t.Fatalf("decoded length = %d, want %d", len(args[2]), len(rawBinary))
 	}
+	// 16 bytes -> 24 base64 chars + 7-char marker = 31; shrink = 31 - 16 = 15.
+	if wantShrink := uint64(len(binaryArgMarker) + 24 - len(rawBinary)); shrink != wantShrink {
+		t.Fatalf("shrink = %d, want %d", shrink, wantShrink)
+	}
 }
 
 func TestDecodeBinaryArgsLeavesUnmarkedArgsUntouched(t *testing.T) {
-	args := []string{"doc:1", "title", "hello __b64 world", "SGVsbG8="}
-	want := []string{"doc:1", "title", "hello __b64 world", "SGVsbG8="}
-	decodeBinaryArgs(args)
+	// Includes a single-underscore near-miss ("hello __b64 world") and a bare
+	// base64-looking token that is NOT marker-prefixed — both pass through.
+	args := []string{"doc:1", "title", "hello __b64 world", "SGVsbG8=", "x__b64__notprefix"}
+	want := []string{"doc:1", "title", "hello __b64 world", "SGVsbG8=", "x__b64__notprefix"}
+	shrink, err := decodeBinaryArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if shrink != 0 {
+		t.Fatalf("shrink = %d, want 0 (no marked args)", shrink)
+	}
 	for i := range args {
 		if args[i] != want[i] {
 			t.Fatalf("unmarked arg %d modified: got %q, want %q", i, args[i], want[i])
 		}
+	}
+}
+
+// A malformed base64 payload must be REPORTED as an error, not fatally abort
+// the process — so the caller can honor -continue-on-error.
+func TestDecodeBinaryArgsRejectsBadBase64(t *testing.T) {
+	args := []string{"doc:1", "vec", binaryArgMarker + "@@not-valid-base64@@"}
+	if _, err := decodeBinaryArgs(args); err == nil {
+		t.Fatal("expected an error for invalid base64, got nil")
+	}
+}
+
+// A URL-safe payload is NOT standard base64 and must be rejected (pins the
+// documented StdEncoding-only contract).
+func TestDecodeBinaryArgsRejectsNonStdEncoding(t *testing.T) {
+	urlSafe := base64.URLEncoding.EncodeToString([]byte{0xff, 0xfe, 0xfd}) // "__79" in URL alphabet
+	if !strings.ContainsAny(urlSafe, "-_") {
+		t.Skipf("payload %q has no URL-safe-specific chars; test is vacuous", urlSafe)
+	}
+	args := []string{"vec", binaryArgMarker + urlSafe}
+	if _, err := decodeBinaryArgs(args); err == nil {
+		t.Fatalf("expected StdEncoding to reject URL-safe payload %q", urlSafe)
+	}
+}
+
+// An empty payload (`__b64__` with nothing after it) is corrupt for a binary
+// field — it would ship a zero-length blob and silently fail indexing.
+func TestDecodeBinaryArgsRejectsEmptyBlob(t *testing.T) {
+	if _, err := decodeBinaryArgs([]string{binaryArgMarker}); err == nil {
+		t.Fatal("expected an error for empty base64 payload, got nil")
 	}
 }
 
@@ -52,5 +100,151 @@ func TestPreProcessCmdDecodesMarkedFieldInHSET(t *testing.T) {
 	}
 	if args[2] != string(rawBinary) {
 		t.Fatalf("vector arg not decoded: got %d bytes, want %d raw bytes", len(args[2]), len(rawBinary))
+	}
+}
+
+// The byte counter used for reported wire throughput must reflect the decoded
+// blob actually sent to Redis, not the larger base64 text in the row.
+func TestPreProcessCmdBytelenReflectsDecodedSize(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString(rawBinary) // 16B -> 24 chars
+	field := binaryArgMarker + encoded                      // 7 + 24 = 31 chars
+	row := "SETUP,setup-doc-1,1,HSET,doc:1,vec," + field
+	_, _, _, _, _, _, _, bytelen, err := preProcessCmd(row)
+	if err != nil {
+		t.Fatalf("preProcessCmd returned error: %v", err)
+	}
+	shrink := uint64(len(field) - len(rawBinary)) // 31 - 16 = 15
+	want := uint64(len(row)) - uint64(len("SETUP")) - shrink
+	if bytelen != want {
+		t.Fatalf("bytelen = %d, want %d (must reflect decoded 16B, not encoded 31B)", bytelen, want)
+	}
+	if bytelen >= uint64(len(row)) {
+		t.Fatalf("bytelen %d should be < raw row length %d when a __b64__ field is present", bytelen, len(row))
+	}
+}
+
+// A corrupt marked arg surfaces as a returned error (NOT os.Exit), so the
+// worker can skip the row under -continue-on-error.
+func TestPreProcessCmdBadBase64ReturnsError(t *testing.T) {
+	row := "SETUP,setup-doc-1,1,HSET,doc:1,vec," + binaryArgMarker + "not_base64!!"
+	if _, _, _, _, _, _, _, _, err := preProcessCmd(row); err == nil {
+		t.Fatal("expected preProcessCmd to return an error for corrupt base64, got nil")
+	}
+}
+
+// Vector benchmarks issue KNN *queries*, not just ingest. A base64 BLOB param
+// on a READ/FT.SEARCH row must be decoded on the same path.
+func TestPreProcessCmdDecodesMarkedBlobInQuery(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString(rawBinary)
+	row := "READ,knn-1,1,FT.SEARCH,idx,*=>[KNN 10 @vec $BLOB],PARAMS,2,BLOB," + binaryArgMarker + encoded + ",DIALECT,2"
+	cmdType, _, _, cmd, key, _, args, _, err := preProcessCmd(row)
+	if err != nil {
+		t.Fatalf("preProcessCmd returned error: %v", err)
+	}
+	if cmdType != "READ" || cmd != "FT.SEARCH" || key != "idx" {
+		t.Fatalf("unexpected parse: cmdType=%q cmd=%q key=%q", cmdType, cmd, key)
+	}
+	// The BLOB value is the arg immediately after the literal "BLOB".
+	blobIdx := -1
+	for i, a := range args {
+		if a == "BLOB" && i+1 < len(args) {
+			blobIdx = i + 1
+			break
+		}
+	}
+	if blobIdx == -1 {
+		t.Fatalf("could not locate BLOB param in args: %q", args)
+	}
+	if args[blobIdx] != string(rawBinary) {
+		t.Fatalf("query BLOB not decoded: got %d bytes, want %d raw bytes", len(args[blobIdx]), len(rawBinary))
+	}
+}
+
+// Every marked arg in a row is decoded, not just the first.
+func TestPreProcessCmdDecodesMultipleMarkedArgs(t *testing.T) {
+	enc := base64.StdEncoding.EncodeToString(rawBinary)
+	row := "SETUP,doc-1,1,HSET,doc:1,vec1," + binaryArgMarker + enc + ",vec2," + binaryArgMarker + enc
+	_, _, _, _, _, _, args, _, err := preProcessCmd(row)
+	if err != nil {
+		t.Fatalf("preProcessCmd returned error: %v", err)
+	}
+	// args = [doc:1, vec1, <raw>, vec2, <raw>]
+	if len(args) != 5 {
+		t.Fatalf("expected 5 args, got %d: %q", len(args), args)
+	}
+	if args[2] != string(rawBinary) || args[4] != string(rawBinary) {
+		t.Fatal("expected both marked vector args to be decoded to raw bytes")
+	}
+}
+
+// Backward-compat regression guard: a plain row with NO marker parses exactly
+// as before — values untouched, key correct, bytelen = len(row)-len(cmdType).
+func TestPreProcessCmdPlainRowUnchanged(t *testing.T) {
+	row := "SETUP,doc-1,1,HSET,doc:1,title,hello world"
+	cmdType, _, _, cmd, key, _, args, bytelen, err := preProcessCmd(row)
+	if err != nil {
+		t.Fatalf("preProcessCmd returned error: %v", err)
+	}
+	if cmdType != "SETUP" || cmd != "HSET" || key != "doc:1" {
+		t.Fatalf("unexpected parse: cmdType=%q cmd=%q key=%q", cmdType, cmd, key)
+	}
+	if len(args) != 3 || args[0] != "doc:1" || args[1] != "title" || args[2] != "hello world" {
+		t.Fatalf("plain args altered: %q", args)
+	}
+	if want := uint64(len(row)) - uint64(len("SETUP")); bytelen != want {
+		t.Fatalf("bytelen = %d, want %d (no shrink expected without a marker)", bytelen, want)
+	}
+}
+
+// Documents the reserved-token behavior: a value whose literal prefix is
+// __b64__ IS interpreted as a marker. Pins the conscious design decision so any
+// future change to it is deliberate.
+func TestPreProcessCmdMarkerPrefixIsReserved(t *testing.T) {
+	// "__b64__SGVsbG8=" -> decodes "SGVsbG8=" -> "Hello".
+	row := "SETUP,doc-1,1,HSET,doc:1,title," + binaryArgMarker + "SGVsbG8="
+	_, _, _, _, _, _, args, _, err := preProcessCmd(row)
+	if err != nil {
+		t.Fatalf("preProcessCmd returned error: %v", err)
+	}
+	if args[2] != "Hello" {
+		t.Fatalf("expected reserved marker prefix to decode to %q, got %q", "Hello", args[2])
+	}
+}
+
+// A too-short row returns an error (previously silently discarded at the call
+// site). Pins the len<3 branch.
+func TestPreProcessCmdShortRowReturnsError(t *testing.T) {
+	if _, _, _, _, _, _, _, _, err := preProcessCmd("a,b"); err == nil {
+		t.Fatal("expected an error for a row with fewer than 3 fields, got nil")
+	}
+}
+
+// A key position derived from an out-of-range pos field must return an error,
+// not panic the worker goroutine (which has no recover).
+func TestPreProcessCmdKeyPosOutOfRangeReturnsError(t *testing.T) {
+	// pos=4 -> keyPos=7, but the row has only 7 fields (indices 0..6).
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("preProcessCmd panicked instead of returning an error: %v", r)
+		}
+	}()
+	if _, _, _, _, _, _, _, _, err := preProcessCmd("SETUP,q,4,HSET,doc:1,f,v"); err == nil {
+		t.Fatal("expected an out-of-range key position to return an error, got nil")
+	}
+}
+
+// Pins keyPos math + cluster-slot computation for a READ row (no prior test
+// covered slot computation).
+func TestPreProcessCmdReadComputesClusterSlot(t *testing.T) {
+	row := "READ,q1,1,FT.SEARCH,idx,*"
+	cmdType, _, keyPos, cmd, key, clusterSlot, _, _, err := preProcessCmd(row)
+	if err != nil {
+		t.Fatalf("preProcessCmd returned error: %v", err)
+	}
+	if cmdType != "READ" || cmd != "FT.SEARCH" || key != "idx" || keyPos != 4 {
+		t.Fatalf("unexpected parse: cmdType=%q cmd=%q key=%q keyPos=%d", cmdType, cmd, key, keyPos)
+	}
+	if want := int(radix.ClusterSlot([]byte("idx"))); clusterSlot != want {
+		t.Fatalf("clusterSlot = %d, want %d", clusterSlot, want)
 	}
 }

--- a/cmd/ftsb_redisearch/cmd_processor_test.go
+++ b/cmd/ftsb_redisearch/cmd_processor_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// A 16-byte little-endian float32 payload whose bytes include 0x0A (newline)
+// and 0x2C (comma) — exactly the bytes that can't travel raw through the
+// line-oriented CSV input.
+var rawBinary = []byte{
+	0x0a, 0x2c, 0x00, 0x3f,
+	0xcd, 0xcc, 0x4c, 0x3e,
+	0x9a, 0x99, 0x99, 0x3e,
+	0xcd, 0xcc, 0xcc, 0x3e,
+}
+
+func TestDecodeBinaryArgsDecodesMarkedArg(t *testing.T) {
+	args := []string{"doc:1", "vec", binaryArgMarker + base64.StdEncoding.EncodeToString(rawBinary)}
+	decodeBinaryArgs(args)
+	if args[2] != string(rawBinary) {
+		t.Fatalf("marked arg not decoded to raw bytes: got %q", args[2])
+	}
+	if len(args[2]) != len(rawBinary) {
+		t.Fatalf("decoded length = %d, want %d", len(args[2]), len(rawBinary))
+	}
+}
+
+func TestDecodeBinaryArgsLeavesUnmarkedArgsUntouched(t *testing.T) {
+	args := []string{"doc:1", "title", "hello __b64 world", "SGVsbG8="}
+	want := []string{"doc:1", "title", "hello __b64 world", "SGVsbG8="}
+	decodeBinaryArgs(args)
+	for i := range args {
+		if args[i] != want[i] {
+			t.Fatalf("unmarked arg %d modified: got %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestPreProcessCmdDecodesMarkedFieldInHSET(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString(rawBinary)
+	row := "SETUP,setup-doc-1,1,HSET,doc:1,vec," + binaryArgMarker + encoded
+	cmdType, _, _, cmd, key, _, args, _, err := preProcessCmd(row)
+	if err != nil {
+		t.Fatalf("preProcessCmd returned error: %v", err)
+	}
+	if cmdType != "SETUP" || cmd != "HSET" || key != "doc:1" {
+		t.Fatalf("unexpected parse: cmdType=%q cmd=%q key=%q", cmdType, cmd, key)
+	}
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %q", len(args), args)
+	}
+	if args[2] != string(rawBinary) {
+		t.Fatalf("vector arg not decoded: got %d bytes, want %d raw bytes", len(args[2]), len(rawBinary))
+	}
+}

--- a/cmd/ftsb_redisearch/main.go
+++ b/cmd/ftsb_redisearch/main.go
@@ -14,14 +14,14 @@ import (
 
 // Program option vars:
 var (
-	host          string
-	password      string
-	debug         int
-	loader        *benchmark_runner.BenchmarkRunner
-	pipeline      int
-	clusterMode   bool
-	continueOnErr bool
-	timeout       time.Duration
+	host           string
+	password       string
+	debug          int
+	loader         *benchmark_runner.BenchmarkRunner
+	pipeline       int
+	clusterMode    bool
+	continueOnErr  bool
+	timeout        time.Duration
 	versionFlag    bool
 	logFile        string
 	timeoutSeconds int

--- a/cmd/ftsb_redisearch/main.go
+++ b/cmd/ftsb_redisearch/main.go
@@ -22,8 +22,9 @@ var (
 	clusterMode   bool
 	continueOnErr bool
 	timeout       time.Duration
-	versionFlag   bool
-	logFile       string
+	versionFlag    bool
+	logFile        string
+	timeoutSeconds int
 )
 
 // Parse args:
@@ -35,10 +36,15 @@ func init() {
 	flag.BoolVar(&continueOnErr, "continue-on-error", true, "If set to true, it will continue the benchmark and print the error message to stderr.")
 	flag.BoolVar(&clusterMode, "cluster-mode", false, "If set to true, it will run the client in cluster mode.")
 	flag.IntVar(&pipeline, "pipeline", 1, "Pipeline <numreq> requests. Default 1 (no pipeline).")
-	var timeoutSeconds int
 	flag.IntVar(&timeoutSeconds, "timeout", 60, "Redis connection timeout in seconds.")
 	flag.BoolVar(&versionFlag, "version", false, "Print the version and exit.")
 	flag.StringVar(&logFile, "log-file", "", "File to write all log output (in addition to stdout/stderr). If not set, logs only to stdout/stderr.")
+}
+
+// parseFlags parses the command line after all flags are declared. Parsing
+// happens in main (not init) so `go test` can run this package — the test
+// harness passes -test.* flags that a parse-at-init would reject.
+func parseFlags() {
 	flag.Parse()
 	// Convert seconds to time.Duration
 	timeout = time.Duration(timeoutSeconds) * time.Second
@@ -92,6 +98,7 @@ func (b *benchmark) GetProcessor() benchmark_runner.Processor {
 }
 
 func main() {
+	parseFlags()
 	b := benchmark{}
 	git_sha := toolGitSHA1()
 	git_dirty_str := ""


### PR DESCRIPTION
## Why

Vector benchmarks need to ingest raw binary blobs (e.g. a 4096-byte little-endian float32 blob for a 1024-dim `FLOAT32` vector field), but the line-oriented CSV input can't carry them:

- raw blobs contain `0x0A` bytes that break the line scanner (`bufio.Scanner`/ScanLines in `scan.go`), and
- storing base64 *as-is* doesn't work either — RediSearch rejects the value on ingest with a blob-size mismatch (`document.c` expects exactly `dim * sizeof(type)` bytes), verified empirically (`hash_indexing_failures` increments, doc not indexed).

Discussed with @filipecosta90 — base64 transport with decode-before-send.

## What

Generators emit `__b64__<base64>` for binary arguments. `preProcessCmd` now base64-decodes any `__b64__`-marked argument back to raw bytes right before the command is sent to Redis.

- **Backward-compatible**: unmarked arguments are untouched; existing input files behave identically.
- **Fail-fast**: a marked argument that fails to decode aborts the run (`preProcessCmd`'s error return is discarded at its call site, so silently continuing would ingest garbage).
- `flag.Parse()` moved from `init()` to `main()` (`parseFlags()` helper) so `go test` can run this package — the test harness passes `-test.*` flags that parse-at-init rejects. This is why the package previously had no tests.
- Adds unit tests: decode-to-exact-raw-bytes (payload deliberately contains `0x0A`/`0x2C`), unmarked-args-untouched, and a full `preProcessCmd` HSET-line parse.

Example input line:

```
SETUP,setup-doc-1,1,HSET,doc:1,vec,__b64__zczMPc3MTD6amZk+zczMPg==
```

executes `HSET doc:1 vec <16 raw bytes>`.

## Verification

- `go build` / `go vet` / `go test` green.
- E2E against redis-stack: `__b64__` CSV → ftsb → stored value is the exact raw bytes, `FT.INFO num_docs` 1, `hash_indexing_failures` 0, KNN query returns the doc. Without the patch the same ingest is rejected by the indexer.

## Note

`.gitignore`'s `ftsb_redisearch` entry (intended for the built binary) also matches the `cmd/ftsb_redisearch/` directory, so new files there are silently ignored (`git check-ignore`); the test file is force-added. Happy to root-anchor those entries (`/ftsb_redisearch`) in this PR or a follow-up if you prefer.

---
First consumer: RediSearchEnterprise disk-HNSW vector benchmarks (MOD-16439, msmarco-v2.1 Cohere embeddings).
