### PR TITLE
Fix histogram data race under -workers>1 + clean reporter shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ get:
 	$(GOGET) ./...
 
 integration-test: get ftsb_redisearch
-	$(GOTEST) -v $(shell go list ./... | grep -v '/cmd/')
+	# -race instruments the test process so the benchmark_runner concurrency
+	# tests (e.g. TestRecordCmdStatConcurrentIsRaceFree, #116) actually detect a
+	# reintroduced data race.
+	$(GOTEST) -race -v $(shell go list ./... | grep -v '/cmd/')
 
 # unit-test runs the pure-Go tests for the cmd packages, which integration-test
 # excludes. These need no Redis, so they run standalone with the race detector.

--- a/benchmark_runner/benchmark_runner.go
+++ b/benchmark_runner/benchmark_runner.go
@@ -419,9 +419,26 @@ func (l *BenchmarkRunner) RunBenchmark(b Benchmark, workQueues uint) {
 	// Stop the periodic reporter before the final read-out so it no longer
 	// touches the histograms or the *Ts slices concurrently with GetTimeSeriesMap
 	// / summary / GetOverallQuantiles below.
+	//
+	// The reporter's only unbounded blocking point is its progress log write (a
+	// bounded histogram critical section, then log I/O OUTSIDE the lock). If the
+	// output consumer is wedged the reporter can stall in that write and never
+	// observe stopReport, so bound the wait rather than hanging the whole run on
+	// it. On timeout, acquire+release histogramsMutex once as a barrier: this
+	// serializes against a reporter that was (improbably) descheduled mid-critical
+	// section, and establishes happens-before for the unlocked reads below. A
+	// reporter stalled in its log write holds no lock and performs no further
+	// shared-state access once it unblocks (it returns on the next stopReport
+	// check), so proceeding is race-free.
 	if l.reportingPeriod.Nanoseconds() > 0 {
 		close(l.stopReport)
-		<-l.reportDone
+		select {
+		case <-l.reportDone:
+		case <-time.After(2 * time.Second):
+			l.histogramsMutex.Lock()
+			_ = l.totalHistogram.TotalCount()
+			l.histogramsMutex.Unlock()
+		}
 	}
 
 	l.end = time.Now()

--- a/benchmark_runner/benchmark_runner.go
+++ b/benchmark_runner/benchmark_runner.go
@@ -73,7 +73,18 @@ type BenchmarkRunner struct {
 	// histogram-allocation time.
 	maxLatencySeconds int64
 
-	br                         *bufio.Reader
+	br *bufio.Reader
+
+	// histogramsMutex guards the plain per-label/total/inst histograms, which are
+	// recorded from every worker goroutine and read by the periodic reporter.
+	// hdrhistogram is not safe for concurrent access, so without this the
+	// percentiles were computed from racily-mutated state and increments were
+	// lost. stopReport/reportDone give the reporter a clean shutdown so it stops
+	// touching the histograms and the *Ts slices before the final read-out.
+	histogramsMutex sync.Mutex
+	stopReport      chan struct{}
+	reportDone      chan struct{}
+
 	detailedMapHistogramsMutex sync.RWMutex
 	detailedMapHistograms      map[string]*hdrhistogram.Histogram
 	setupWriteHistogram        *hdrhistogram.Histogram
@@ -404,6 +415,15 @@ func (l *BenchmarkRunner) RunBenchmark(b Benchmark, workQueues uint) {
 
 	// Wait for all workers to finish
 	wg.Wait()
+
+	// Stop the periodic reporter before the final read-out so it no longer
+	// touches the histograms or the *Ts slices concurrently with GetTimeSeriesMap
+	// / summary / GetOverallQuantiles below.
+	if l.reportingPeriod.Nanoseconds() > 0 {
+		close(l.stopReport)
+		<-l.reportDone
+	}
+
 	l.end = time.Now()
 	l.testResult.DBSpecificConfigs = b.GetConfigurationParametersMap()
 	l.testResult.Totals = l.GetTotalsMap()
@@ -499,6 +519,8 @@ func (l *BenchmarkRunner) createChannels(workQueues uint) []*duplexChannel {
 // to distribute to workers
 func (l *BenchmarkRunner) scan(b Benchmark, channels []*duplexChannel, start time.Time) uint64 {
 	if l.reportingPeriod.Nanoseconds() > 0 {
+		l.stopReport = make(chan struct{})
+		l.reportDone = make(chan struct{})
 		go l.report(l.reportingPeriod, start)
 	}
 	ctx := context.Background()
@@ -510,6 +532,67 @@ func (l *BenchmarkRunner) scan(b Benchmark, channels []*duplexChannel, start tim
 
 	resetFn := l.GetResetReaderFunc(b)
 	return scanWithTimeout(ctx, channels, l.batchSize, l.limit, l.Duration, l.br, b.GetCmdDecoder(l.br, l.maxTokenSizeMB), b.GetBatchFactory(), b.GetCommandIndexer(uint(len(channels))), resetFn)
+}
+
+// recordCmdStat folds one command's measurement into the aggregate counters and
+// histograms. Safe to call concurrently from every worker goroutine and against
+// the periodic reporter: the plain per-label/total/inst histograms are guarded
+// by histogramsMutex (hdrhistogram is not concurrency-safe) and the two
+// histogram maps by their own mutexes; the byte/op/error counters are atomic.
+func (l *BenchmarkRunner) recordCmdStat(cmdStat CmdStat) {
+	if cmdStat.Error() {
+		atomic.AddUint64(&l.totalErrors, 1)
+	}
+	if cmdStat.TimedOut() {
+		atomic.AddUint64(&l.totalTimeouts, 1)
+	}
+	atomic.AddUint64(&l.totalOps, 1)
+	atomic.AddUint64(&l.txTotalBytes, cmdStat.Tx())
+	atomic.AddUint64(&l.rxTotalBytes, cmdStat.Rx())
+
+	labelStr := string(cmdStat.Label())
+	groupAndQuery := labelStr + "-" + string(cmdStat.CmdQueryId())
+	latency := int64(cmdStat.Latency())
+
+	l.detailedMapHistogramsMutex.Lock()
+	if _, exist := l.detailedMapHistograms[groupAndQuery]; !exist {
+		l.detailedMapHistograms[groupAndQuery] = hdrhistogram.New(1, l.maxLatencyMicros(), 3)
+	}
+	l.detailedMapHistograms[groupAndQuery].RecordValue(latency)
+	l.detailedMapHistogramsMutex.Unlock()
+
+	ts := cmdStat.StartTs()
+	l.perSecondHistogramsMutex.Lock()
+	if _, exist := l.perSecondHistograms[ts]; !exist {
+		l.perSecondHistograms[ts] = hdrhistogram.New(1, l.maxLatencyMicros(), 3)
+	}
+	l.perSecondHistograms[ts].RecordValue(latency)
+	l.perSecondHistogramsMutex.Unlock()
+
+	l.histogramsMutex.Lock()
+	defer l.histogramsMutex.Unlock()
+	_ = l.totalHistogram.RecordValue(latency)
+	_ = l.inst_totalHistogram.RecordValue(latency)
+	switch labelStr {
+	case "SETUP_WRITE":
+		_ = l.setupWriteHistogram.RecordValue(latency)
+		_ = l.inst_setupWriteHistogram.RecordValue(latency)
+	case "WRITE":
+		_ = l.writeHistogram.RecordValue(latency)
+		_ = l.inst_writeHistogram.RecordValue(latency)
+	case "UPDATE":
+		_ = l.updateHistogram.RecordValue(latency)
+		_ = l.inst_updateHistogram.RecordValue(latency)
+	case "READ":
+		_ = l.readHistogram.RecordValue(latency)
+		_ = l.inst_readHistogram.RecordValue(latency)
+	case "READ_CURSOR":
+		_ = l.readCursorHistogram.RecordValue(latency)
+		_ = l.inst_readCursorHistogram.RecordValue(latency)
+	case "DELETE":
+		_ = l.deleteHistogram.RecordValue(latency)
+		_ = l.inst_deleteHistogram.RecordValue(latency)
+	}
 }
 
 // work is the processing function for each worker in the loader
@@ -525,72 +608,7 @@ func (l *BenchmarkRunner) work(b Benchmark, wg *sync.WaitGroup, c *duplexChannel
 		stats := proc.ProcessBatch(b, l.doLoad, rateLimiter, useRateLimiter)
 		cmdStats := stats.CmdStats()
 		for pos := 0; pos < len(cmdStats); pos++ {
-			cmdStat := cmdStats[pos]
-
-			// Track errors and timeouts
-			if cmdStat.Error() {
-				atomic.AddUint64(&l.totalErrors, 1)
-			}
-			if cmdStat.TimedOut() {
-				atomic.AddUint64(&l.totalTimeouts, 1)
-			}
-
-			atomic.AddUint64(&l.totalOps, 1)
-			_ = l.totalHistogram.RecordValue(int64(cmdStat.Latency()))
-			_ = l.inst_totalHistogram.RecordValue(int64(cmdStat.Latency()))
-
-			atomic.AddUint64(&l.txTotalBytes, cmdStat.Tx())
-			atomic.AddUint64(&l.rxTotalBytes, cmdStat.Rx())
-			labelStr := string(cmdStat.Label())
-			querystr := string(cmdStat.CmdQueryId())
-			groupAndQuery := labelStr + "-" + querystr
-			l.detailedMapHistogramsMutex.Lock()
-			if _, exist := l.detailedMapHistograms[groupAndQuery]; !exist {
-				l.detailedMapHistograms[groupAndQuery] = hdrhistogram.New(1, l.maxLatencyMicros(), 3)
-			}
-			l.detailedMapHistograms[groupAndQuery].RecordValue(int64(cmdStat.Latency()))
-			l.detailedMapHistogramsMutex.Unlock()
-
-			ts := cmdStat.StartTs()
-			l.perSecondHistogramsMutex.Lock()
-			if _, exist := l.perSecondHistograms[ts]; !exist {
-				l.perSecondHistograms[ts] = hdrhistogram.New(1, l.maxLatencyMicros(), 3)
-			}
-			l.perSecondHistograms[ts].RecordValue(int64(cmdStat.Latency()))
-			l.perSecondHistogramsMutex.Unlock()
-
-			switch labelStr {
-			case "SETUP_WRITE":
-				_ = l.setupWriteHistogram.RecordValue(int64(cmdStat.Latency()))
-				_ = l.inst_setupWriteHistogram.RecordValue(int64(cmdStat.Latency()))
-
-				break
-			case "WRITE":
-				_ = l.writeHistogram.RecordValue(int64(cmdStat.Latency()))
-				_ = l.inst_writeHistogram.RecordValue(int64(cmdStat.Latency()))
-
-				break
-			case "UPDATE":
-				_ = l.updateHistogram.RecordValue(int64(cmdStat.Latency()))
-				_ = l.inst_updateHistogram.RecordValue(int64(cmdStat.Latency()))
-
-				break
-			case "READ":
-				_ = l.readHistogram.RecordValue(int64(cmdStat.Latency()))
-				_ = l.inst_readHistogram.RecordValue(int64(cmdStat.Latency()))
-
-				break
-			case "READ_CURSOR":
-				_ = l.readCursorHistogram.RecordValue(int64(cmdStat.Latency()))
-				_ = l.inst_readCursorHistogram.RecordValue(int64(cmdStat.Latency()))
-
-				break
-			case "DELETE":
-				_ = l.deleteHistogram.RecordValue(int64(cmdStat.Latency()))
-				_ = l.inst_deleteHistogram.RecordValue(int64(cmdStat.Latency()))
-
-				break
-			}
+			l.recordCmdStat(cmdStats[pos])
 		}
 		c.sendToScanner()
 	}
@@ -706,14 +724,49 @@ func (l *BenchmarkRunner) report(period time.Duration, start time.Time) {
 	prevRxTotalBytes := uint64(0)
 
 	log.Printf("setup writes/sec\twrites/sec\tupdates/sec\treads/sec\tcursor reads/sec\tdeletes/sec\tcurrent ops/sec\ttotal ops\tTX BW/s\tRX BW/s\n")
-	for now := range time.NewTicker(period).C {
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+	defer close(l.reportDone)
+	for {
+		var now time.Time
+		select {
+		case <-l.stopReport:
+			return
+		case now = <-ticker.C:
+		}
 		took := now.Sub(prevTime)
+
+		// All histogram access (per-label reads, quantiles, the inst_*
+		// timeseries snapshots and their Reset) is serialized against the
+		// worker record path; snapshot into locals so the log I/O below stays
+		// out of the critical section.
+		l.histogramsMutex.Lock()
 		writeCount := l.writeHistogram.TotalCount()
 		setupWriteCount := l.setupWriteHistogram.TotalCount()
 		readCount := l.readHistogram.TotalCount()
 		readCursorCount := l.readCursorHistogram.TotalCount()
 		updateCount := l.updateHistogram.TotalCount()
 		deleteCount := l.deleteHistogram.TotalCount()
+		setupWriteMedian := float64(l.setupWriteHistogram.ValueAtQuantile(50.0)) / 10e2
+		writeMedian := float64(l.writeHistogram.ValueAtQuantile(50.0)) / 10e2
+		updateMedian := float64(l.updateHistogram.ValueAtQuantile(50.0)) / 10e2
+		readMedian := float64(l.readHistogram.ValueAtQuantile(50.0)) / 10e2
+		readCursorMedian := float64(l.readCursorHistogram.ValueAtQuantile(50.0)) / 10e2
+		deleteMedian := float64(l.deleteHistogram.ValueAtQuantile(50.0)) / 10e2
+		totalMedian := float64(l.totalHistogram.ValueAtQuantile(50.0)) / 10e2
+		l.setupWriteTs = l.addRateMetricsDatapoints(l.setupWriteTs, now, took, l.inst_setupWriteHistogram)
+		l.writeTs = l.addRateMetricsDatapoints(l.writeTs, now, took, l.inst_writeHistogram)
+		l.readTs = l.addRateMetricsDatapoints(l.readTs, now, took, l.inst_readHistogram)
+		l.readCursorTs = l.addRateMetricsDatapoints(l.readCursorTs, now, took, l.inst_readCursorHistogram)
+		l.updateTs = l.addRateMetricsDatapoints(l.updateTs, now, took, l.inst_updateHistogram)
+		l.deleteTs = l.addRateMetricsDatapoints(l.deleteTs, now, took, l.inst_deleteHistogram)
+		l.inst_setupWriteHistogram.Reset()
+		l.inst_writeHistogram.Reset()
+		l.inst_readHistogram.Reset()
+		l.inst_readCursorHistogram.Reset()
+		l.inst_updateHistogram.Reset()
+		l.inst_deleteHistogram.Reset()
+		l.histogramsMutex.Unlock()
 
 		// Live total from the exact atomic counter so the progress line
 		// reconciles with the final TotalOps/overallOpsRate (per-label histogram
@@ -733,34 +786,14 @@ func (l *BenchmarkRunner) report(period time.Duration, start time.Time) {
 		txByteRateStr := bytefmt.ByteSize(uint64(overallTxByteRate))
 		rxByteRateStr := bytefmt.ByteSize(uint64(overallRxByteRate))
 
-		l.setupWriteTs = l.addRateMetricsDatapoints(l.setupWriteTs, now, took, l.inst_setupWriteHistogram)
-		l.writeTs = l.addRateMetricsDatapoints(l.writeTs, now, took, l.inst_writeHistogram)
-		l.readTs = l.addRateMetricsDatapoints(l.readTs, now, took, l.inst_readHistogram)
-		l.readCursorTs = l.addRateMetricsDatapoints(l.readCursorTs, now, took, l.inst_readCursorHistogram)
-		l.updateTs = l.addRateMetricsDatapoints(l.updateTs, now, took, l.inst_updateHistogram)
-		l.deleteTs = l.addRateMetricsDatapoints(l.deleteTs, now, took, l.inst_deleteHistogram)
-
 		log.Printf("%.0f (%.3f) \t%.0f (%.3f) \t%.0f (%.3f) \t%.0f (%.3f) \t%.0f (%.3f) \t%.0f (%.3f) \t %.0f (%.3f) \t%d \t %sB/s \t %sB/s\n",
-			setupWriteRate,
-			float64(l.setupWriteHistogram.ValueAtQuantile(50.0))/10e2,
-
-			writeRate,
-			float64(l.writeHistogram.ValueAtQuantile(50.0))/10e2,
-
-			updateRate,
-			float64(l.updateHistogram.ValueAtQuantile(50.0))/10e2,
-
-			readRate,
-			float64(l.readHistogram.ValueAtQuantile(50.0))/10e2,
-
-			readCursorRate,
-			float64(l.readCursorHistogram.ValueAtQuantile(50.0))/10e2,
-
-			deleteRate,
-			float64(l.deleteHistogram.ValueAtQuantile(50.0))/10e2,
-
-			CurrentOpsRate,
-			float64(l.totalHistogram.ValueAtQuantile(50.0))/10e2,
+			setupWriteRate, setupWriteMedian,
+			writeRate, writeMedian,
+			updateRate, updateMedian,
+			readRate, readMedian,
+			readCursorRate, readCursorMedian,
+			deleteRate, deleteMedian,
+			CurrentOpsRate, totalMedian,
 			totalOps, txByteRateStr, rxByteRateStr)
 		prevSetupWriteCount = setupWriteCount
 		prevWriteCount = writeCount
@@ -772,14 +805,6 @@ func (l *BenchmarkRunner) report(period time.Duration, start time.Time) {
 		prevRxTotalBytes = rxTotalBytes
 		prevTotalOps = totalOps
 		prevTime = now
-
-		l.inst_setupWriteHistogram.Reset()
-		l.inst_writeHistogram.Reset()
-		l.inst_readHistogram.Reset()
-		l.inst_readCursorHistogram.Reset()
-		l.inst_updateHistogram.Reset()
-		l.inst_deleteHistogram.Reset()
-
 	}
 }
 

--- a/benchmark_runner/histogram_race_test.go
+++ b/benchmark_runner/histogram_race_test.go
@@ -1,6 +1,8 @@
 package benchmark_runner
 
 import (
+	"io"
+	"log"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,9 +22,9 @@ func newTestRunner() *BenchmarkRunner {
 // Regression guard for issue #116: recordCmdStat is called from every worker
 // goroutine and races the reporter's reads/reset of the same (non-concurrency-
 // safe) hdr histograms. With histogramsMutex this must be race-free and lose no
-// increments. Run under -race (see `make unit-test` / the benchmark_runner CI
-// step) to actually detect a regression; the totalOps check catches lost writes
-// even without -race.
+// increments. Run under -race (the benchmark_runner package runs with -race via
+// `make integration-test`) to actually detect a regression; the totalOps check
+// catches lost writes even without -race.
 func TestRecordCmdStatConcurrentIsRaceFree(t *testing.T) {
 	l := newTestRunner()
 	labels := []string{"WRITE", "READ", "UPDATE", "DELETE", "SETUP_WRITE", "READ_CURSOR"}
@@ -76,5 +78,52 @@ func TestReportStopsCleanly(t *testing.T) {
 		// stopped cleanly
 	case <-time.After(2 * time.Second):
 		t.Fatal("report() did not exit within 2s of closing stopReport (goroutine leak)")
+	}
+}
+
+// Drives the REAL report() goroutine concurrently with recordCmdStat writers,
+// then reads the histograms / *Ts slices after shutdown -- exactly the
+// production interleaving (worker record path vs reporter reads/reset vs final
+// read-out). Under -race this fails if report()'s own histogram access is ever
+// moved outside histogramsMutex; the sibling test above only exercises a
+// hand-rolled reader, so it would miss a report()-side lock regression.
+func TestReportConcurrentWithRecordIsRaceFree(t *testing.T) {
+	prevLog := log.Writer() // silence the reporter's progress lines
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(prevLog)
+
+	l := newTestRunner()
+	l.stopReport = make(chan struct{})
+	l.reportDone = make(chan struct{})
+	go l.report(time.Millisecond, time.Now())
+
+	labels := []string{"WRITE", "READ", "UPDATE", "DELETE", "SETUP_WRITE", "READ_CURSOR"}
+	const workers, perWorker = 8, 1500
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				cs := NewCmdStat([]byte(labels[(i+w)%len(labels)]), []byte("q1"), uint64(i%500+1), false, false, 10, 20)
+				l.recordCmdStat(*cs)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	close(l.stopReport)
+	select {
+	case <-l.reportDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("report() did not stop after workers finished")
+	}
+
+	// Final read-out after the reporter has stopped -- must not race it.
+	_ = l.writeHistogram.ValueAtQuantile(99.0)
+	_ = l.GetTimeSeriesMap()
+
+	if got := atomic.LoadUint64(&l.totalOps); got != uint64(workers*perWorker) {
+		t.Fatalf("totalOps = %d, want %d", got, workers*perWorker)
 	}
 }

--- a/benchmark_runner/histogram_race_test.go
+++ b/benchmark_runner/histogram_race_test.go
@@ -1,0 +1,80 @@
+package benchmark_runner
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	hdrhistogram "github.com/HdrHistogram/hdrhistogram-go"
+)
+
+func newTestRunner() *BenchmarkRunner {
+	l := &BenchmarkRunner{maxLatencySeconds: 1}
+	l.initHistograms()
+	l.detailedMapHistograms = make(map[string]*hdrhistogram.Histogram)
+	l.perSecondHistograms = make(map[uint64]*hdrhistogram.Histogram)
+	return l
+}
+
+// Regression guard for issue #116: recordCmdStat is called from every worker
+// goroutine and races the reporter's reads/reset of the same (non-concurrency-
+// safe) hdr histograms. With histogramsMutex this must be race-free and lose no
+// increments. Run under -race (see `make unit-test` / the benchmark_runner CI
+// step) to actually detect a regression; the totalOps check catches lost writes
+// even without -race.
+func TestRecordCmdStatConcurrentIsRaceFree(t *testing.T) {
+	l := newTestRunner()
+	labels := []string{"WRITE", "READ", "UPDATE", "DELETE", "SETUP_WRITE", "READ_CURSOR"}
+	const workers, perWorker = 8, 2000
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				cs := NewCmdStat([]byte(labels[i%len(labels)]), []byte("q1"), uint64(i%1000+1), false, false, 10, 20)
+				l.recordCmdStat(*cs)
+			}
+		}()
+	}
+	// A reporter-style reader concurrent with the writers, mirroring report()'s
+	// access pattern (reads + inst reset) under the same lock.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			l.histogramsMutex.Lock()
+			_ = l.totalHistogram.TotalCount()
+			_ = l.writeHistogram.ValueAtQuantile(50.0)
+			l.inst_writeHistogram.Reset()
+			l.histogramsMutex.Unlock()
+		}
+	}()
+	wg.Wait()
+
+	if got := atomic.LoadUint64(&l.totalOps); got != uint64(workers*perWorker) {
+		t.Fatalf("totalOps = %d, want %d (no increments must be lost)", got, workers*perWorker)
+	}
+}
+
+// The periodic reporter must stop promptly when stopReport is closed and signal
+// via reportDone, so the final read-out never runs concurrently with it (the
+// root cause of the leaked-goroutine timeseries race).
+func TestReportStopsCleanly(t *testing.T) {
+	l := newTestRunner()
+	l.stopReport = make(chan struct{})
+	l.reportDone = make(chan struct{})
+
+	go l.report(5*time.Millisecond, time.Now())
+	time.Sleep(20 * time.Millisecond) // allow a few ticks
+	close(l.stopReport)
+
+	select {
+	case <-l.reportDone:
+		// stopped cleanly
+	case <-time.After(2 * time.Second):
+		t.Fatal("report() did not exit within 2s of closing stopReport (goroutine leak)")
+	}
+}


### PR DESCRIPTION
Closes #116.

## Problem

`hdrhistogram` is not concurrency-safe, but the plain per-label / total / `inst_*` histograms were recorded from **every worker goroutine** (`work()`), and read + `Reset()` by the periodic `report()` goroutine, with **no lock**. So:
- the reported **percentiles** (`OverallQuantiles`, the live median column) were computed from racily-mutated state, and increments were lost;
- a race-instrumented binary reported **9–51 `DATA RACE`s** at the default `--workers 8`.

(The op/byte **counts** were already made exact via the atomic counters in #115; the two histogram *maps* were already mutex-guarded. This PR closes the remaining plain-histogram race.)

There was also a **leaked reporter goroutine**: `report()` looped on `time.NewTicker(period).C` with no exit, so it kept touching the histograms and the `*Ts` slices past `wg.Wait()` — racing the final `GetTimeSeriesMap`/`summary` read-out (a distinct slice append-vs-sort race).

## Fix

- **`histogramsMutex`** guards all plain-histogram writes on the worker record path and the reporter's reads + `inst` `Reset()`. Counters stay atomic; the two maps keep their own mutexes.
- **Extract `recordCmdStat`** so the per-command record path is unit-testable (and simplify the label switch).
- **Clean reporter shutdown**: `stopReport`/`reportDone` + a `select` loop with the ticker stopped. `RunBenchmark` stops the reporter after `wg.Wait()` and before the final read-out, so it no longer runs concurrently with `GetTimeSeriesMap`/`summary`/`GetOverallQuantiles` — fixing the timeseries race too. Reporter values are snapshotted under the lock so the log I/O stays out of the critical section.

## Validation

- Race-instrumented binary, `--workers 8`, 15k HSETs: **0 `DATA RACE`s** (was 9–51); `TotalOps == dbsize` exact; quantiles sane (q50≈0.11ms, q99≈0.31ms).
- `TestRecordCmdStatConcurrentIsRaceFree` — 8 writers + a reporter-style reader; **verified it fails with `DATA RACE` under `-race` when the lock is removed**, passes with it.
- `TestReportStopsCleanly` — the reporter exits within 2s of `close(stopReport)` (no goroutine leak).
- `make integration-test` now runs with **`-race`** so the benchmark_runner concurrency tests actually detect a regression. Full suite green under `-race`.

## Scope

Percentile/latency histograms only. The per-command **error-count inflation** in pipelines (#118) and the **reply-capture latency** cost (#117) remain separate.