### PR TITLE
Count pipeline errors per-command, not per-window

### DIFF
--- a/benchmark_runner/redisearch_test.go
+++ b/benchmark_runner/redisearch_test.go
@@ -2,6 +2,7 @@ package benchmark_runner
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -669,5 +670,58 @@ func TestFTSBLatencyCapHighOptIn(t *testing.T) {
 	)
 	if q100 < 1500 {
 		t.Errorf("Expected q100 >= 1500 ms with --max-latency-seconds=60 (DEBUG SLEEP 2 should record ~2000 ms), got %.2f ms", q100)
+	}
+}
+
+// #118: a single failing command in a pipeline window must count as exactly ONE
+// error, not `pipeline` errors. Pre-fix, ftsb attributed the pipeline's single
+// aggregate error to every command in the window, so one WRONGTYPE reply in a
+// window of 10 inflated Errors to 10.
+//
+// The input is self-contained and deterministic under --workers 1: window 0
+// (rows 0-9) does `SET strkey ...` plus 9 good HSETs (all succeed), and window 1
+// (rows 10-19) has exactly one `HSET strkey ...` (WRONGTYPE, strkey is a string)
+// among 9 good HSETs. Correct accounting -> Errors == 1; pre-fix -> Errors == 10.
+func TestFTSBPipelineErrorCountedPerCommandNotPerWindow(t *testing.T) {
+	startRedisContainer(t)
+
+	var b strings.Builder
+	// Window 0: seed strkey as a STRING, then 9 good hashes -> all succeed.
+	b.WriteString("WRITE,q,1,SET,strkey,x\n")
+	for i := 0; i < 9; i++ {
+		fmt.Fprintf(&b, "WRITE,q,1,HSET,good:%d,f,v\n", i)
+	}
+	// Window 1: 5 good, 1 WRONGTYPE (HSET on the string key), 4 good.
+	for i := 9; i < 14; i++ {
+		fmt.Fprintf(&b, "WRITE,q,1,HSET,good:%d,f,v\n", i)
+	}
+	b.WriteString("WRITE,q,1,HSET,strkey,f,v\n") // WRONGTYPE: strkey is a string
+	for i := 14; i < 18; i++ {
+		fmt.Fprintf(&b, "WRITE,q,1,HSET,good:%d,f,v\n", i)
+	}
+
+	csvPath := "../testdata/pipeline_error_input.csv"
+	if err := os.WriteFile(csvPath, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write input csv: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(csvPath) })
+
+	data := runFTSBReadJSON(t, "../testdata/results.pipeline_error.json",
+		"--input", csvPath, "--workers", "1", "--pipeline", "10")
+
+	var parsed struct {
+		Totals struct {
+			TotalOps int     `json:"TotalOps"`
+			Errors   float64 `json:"Errors"`
+		} `json:"Totals"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if parsed.Totals.TotalOps != 20 {
+		t.Errorf("TotalOps = %d, want 20", parsed.Totals.TotalOps)
+	}
+	if parsed.Totals.Errors != 1 {
+		t.Errorf("Errors = %v, want 1 (one WRONGTYPE in a pipeline of 10 must not inflate to 10)", parsed.Totals.Errors)
 	}
 }

--- a/cmd/ftsb_redisearch/cmd_processor.go
+++ b/cmd/ftsb_redisearch/cmd_processor.go
@@ -378,8 +378,11 @@ func flushPending(p *processor, client radix.Client, pending []pendingCmd) ([]pe
 	hadError := false
 
 	// Build the action BEFORE timing so the latency window covers only the
-	// round-trip, not client-side slice bookkeeping.
+	// round-trip, not client-side slice bookkeeping. For a batch we use
+	// pipelineErrs (not radix.Pipeline) so we can attribute failures to the
+	// exact commands that failed instead of blaming the whole window (#118).
 	var action radix.Action
+	var pe *pipelineErrs
 	if len(pending) == 1 {
 		action = pending[0].action // no need to pipeline a single command
 	} else {
@@ -387,16 +390,25 @@ func flushPending(p *processor, client radix.Client, pending []pendingCmd) ([]pe
 		for i := range pending {
 			actions[i] = pending[i].action
 		}
-		action = radix.Pipeline(actions...)
+		pe = &pipelineErrs{cmds: actions, errs: make([]error, len(actions))}
+		action = pe
 	}
 
 	sendT := time.Now()
 	err := client.Do(action)
 	endT := time.Now()
-	isTimeout := false
 	if err != nil {
 		hadError = true
-		isTimeout = logFlushError(pending, err)
+		logFlushError(pending, err)
+	}
+
+	// cmdErr returns command i's own error: for a batch that's pe.errs[i] (only
+	// the commands that actually failed), for a single command it's the Do error.
+	cmdErr := func(i int) error {
+		if pe != nil {
+			return pe.errs[i]
+		}
+		return err
 	}
 
 	// A pipeline is one client round-trip for the whole batch, so attribute the
@@ -409,10 +421,15 @@ func flushPending(p *processor, client radix.Client, pending []pendingCmd) ([]pe
 	took := flooredMicros(endT.Sub(sendT))
 	for i := range pending {
 		pc := &pending[i]
+		// Each command records its OWN error and timeout status (#118): a single
+		// bad reply in a pipeline must not mark its siblings as errored.
+		thisErr := cmdErr(i)
+		cmdHadError := thisErr != nil
+		cmdTimeout := cmdHadError && strings.Contains(thisErr.Error(), "i/o timeout")
 		// AddEntry takes (..., rx, tx): received bytes, then sent bytes. Each
 		// command records its OWN counts and labels.
 		rxBytesCount := getRxLen(pc.reply)
-		stat := benchmark_runner.NewStat().AddEntry([]byte(pc.cmdType), []byte(pc.cmdQueryId), uint64(sendT.Unix()), took, hadError, isTimeout, rxBytesCount, pc.txBytes)
+		stat := benchmark_runner.NewStat().AddEntry([]byte(pc.cmdType), []byte(pc.cmdQueryId), uint64(sendT.Unix()), took, cmdHadError, cmdTimeout, rxBytesCount, pc.txBytes)
 		p.cmdChan <- *stat
 	}
 

--- a/cmd/ftsb_redisearch/cmd_processor.go
+++ b/cmd/ftsb_redisearch/cmd_processor.go
@@ -402,10 +402,18 @@ func flushPending(p *processor, client radix.Client, pending []pendingCmd) ([]pe
 		logFlushError(pending, err)
 	}
 
-	// cmdErr returns command i's own error: for a batch that's pe.errs[i] (only
-	// the commands that actually failed), for a single command it's the Do error.
+	// cmdErr returns command i's own error. For a batch, pe.errs[i] is
+	// authoritative ONCE pe.Run executed (only the commands that actually failed
+	// are non-nil). But client.Do can fail BEFORE pe.Run -- e.g. the pool can't
+	// hand out a connection during a server outage -- in which case pe.errs stays
+	// all-nil even though the whole batch failed; fall back to the Do error so
+	// those commands aren't miscounted as successful. For a single command it's
+	// just the Do error.
 	cmdErr := func(i int) error {
 		if pe != nil {
+			if !pe.ran {
+				return err // batch never executed: whole window failed
+			}
 			return pe.errs[i]
 		}
 		return err

--- a/cmd/ftsb_redisearch/pipeline_action.go
+++ b/cmd/ftsb_redisearch/pipeline_action.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io"
+
+	"github.com/mediocregopher/radix/v3"
+)
+
+// pipelineErrs runs a batch of commands as a single pipeline (one buffered write
+// of every command, one batched read of every reply) but, unlike radix.Pipeline,
+// it decodes EVERY reply and records each command's individual error instead of
+// stopping at the first one.
+//
+// radix.Pipeline's Run stops decoding at the first failing command and DRAINS
+// (discards) the remaining replies, returning a single error for the whole
+// batch. ftsb previously attributed that one error to every command in the
+// window, so a single WRONGTYPE/OOM reply inflated the error count by up to
+// `pipeline` per occurrence (issue #118). Here errs[i] is populated iff command
+// i's reply was an error, so accounting is per-command exact.
+//
+// The write is still a single flush of all commands (via multiMarshal), so this
+// keeps the pipelining benefit; the read cost is identical to radix.Pipeline,
+// which also decodes/drains all N replies.
+type pipelineErrs struct {
+	cmds []radix.CmdAction
+	errs []error // len(cmds); errs[i] != nil iff command i failed.
+}
+
+// multiMarshal marshals a batch of CmdActions into one RESP write so the whole
+// pipeline is sent in a single flush (mirrors radix.Pipeline's own encode path).
+type multiMarshal []radix.CmdAction
+
+func (m multiMarshal) MarshalRESP(w io.Writer) error {
+	for _, cmd := range m {
+		if err := cmd.MarshalRESP(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Keys returns the union of the batch's keys (radix uses this only for cluster
+// routing; ftsb pins a whole batch to one connection so this is informational).
+func (p *pipelineErrs) Keys() []string {
+	var keys []string
+	for _, cmd := range p.cmds {
+		keys = append(keys, cmd.Keys()...)
+	}
+	return keys
+}
+
+func (p *pipelineErrs) Run(c radix.Conn) error {
+	// One buffered write of the whole batch.
+	if err := c.Encode(multiMarshal(p.cmds)); err != nil {
+		// A write failure breaks the connection, so no reply is coming for any
+		// command in the batch: every command failed.
+		for i := range p.cmds {
+			p.errs[i] = err
+		}
+		return err
+	}
+	// One batched read: decode every reply so per-command errors are captured.
+	// A RESP error (e.g. WRONGTYPE) fails only its own command and leaves the
+	// connection healthy for the rest. A transport error (e.g. i/o timeout)
+	// breaks the connection, so that command and every command after it fail;
+	// the ones already decoded succeeded. Either way errs reflects reality
+	// per-command instead of blaming the whole window.
+	var first error
+	for i, cmd := range p.cmds {
+		if err := c.Decode(cmd); err != nil {
+			p.errs[i] = err
+			if first == nil {
+				first = err
+			}
+		}
+	}
+	return first
+}

--- a/cmd/ftsb_redisearch/pipeline_action.go
+++ b/cmd/ftsb_redisearch/pipeline_action.go
@@ -24,6 +24,7 @@ import (
 type pipelineErrs struct {
 	cmds []radix.CmdAction
 	errs []error // len(cmds); errs[i] != nil iff command i failed.
+	ran  bool    // set once Run starts; distinguishes "executed, errs is authoritative" from "client.Do failed before Run (e.g. connection acquisition), whole batch failed".
 }
 
 // multiMarshal marshals a batch of CmdActions into one RESP write so the whole
@@ -50,6 +51,7 @@ func (p *pipelineErrs) Keys() []string {
 }
 
 func (p *pipelineErrs) Run(c radix.Conn) error {
+	p.ran = true
 	// One buffered write of the whole batch.
 	if err := c.Encode(multiMarshal(p.cmds)); err != nil {
 		// A write failure breaks the connection, so no reply is coming for any

--- a/cmd/ftsb_redisearch/pipeline_action_test.go
+++ b/cmd/ftsb_redisearch/pipeline_action_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/mediocregopher/radix/v3"
+	"github.com/mediocregopher/radix/v3/resp"
+)
+
+// fakeConn is a minimal radix.Conn that returns canned per-Decode errors, so we
+// can drive pipelineErrs.Run deterministically through the transport-error paths
+// that a live Redis makes hard to reproduce (issue #118 timeout-tail coverage).
+type fakeConn struct {
+	encodeErr  error
+	decodeErrs []error // one per Decode call, in order
+	decodeAt   int
+}
+
+func (f *fakeConn) Encode(resp.Marshaler) error { return f.encodeErr }
+func (f *fakeConn) Decode(resp.Unmarshaler) error {
+	var e error
+	if f.decodeAt < len(f.decodeErrs) {
+		e = f.decodeErrs[f.decodeAt]
+	}
+	f.decodeAt++
+	return e
+}
+func (f *fakeConn) Do(a radix.Action) error { return a.Run(f) }
+func (f *fakeConn) Close() error            { return nil }
+func (f *fakeConn) NetConn() net.Conn       { return nil }
+
+func newPE(n int) *pipelineErrs {
+	cmds := make([]radix.CmdAction, n)
+	for i := range cmds {
+		cmds[i] = radix.Cmd(nil, "PING")
+	}
+	return &pipelineErrs{cmds: cmds, errs: make([]error, n)}
+}
+
+// A transport error mid-batch fails that command and the ones after it (the
+// connection is broken), while already-decoded commands stay successful. This
+// is exactly the timeout-tail the WRONGTYPE test can't reach.
+func TestPipelineErrsRunRecordsPerCommandTransportError(t *testing.T) {
+	timeout := errors.New("read tcp: i/o timeout")
+	reset := errors.New("read tcp: connection reset by peer")
+	pe := newPE(3)
+	fc := &fakeConn{decodeErrs: []error{nil, timeout, reset}} // cmd0 ok, cmd1 times out, cmd2 on broken conn
+
+	err := pe.Run(fc)
+
+	if !pe.ran {
+		t.Error("ran = false after Run, want true")
+	}
+	if err != timeout {
+		t.Errorf("Run returned %v, want the first error %v", err, timeout)
+	}
+	if pe.errs[0] != nil {
+		t.Errorf("errs[0] = %v, want nil (command succeeded)", pe.errs[0])
+	}
+	if pe.errs[1] != timeout || pe.errs[2] != reset {
+		t.Errorf("errs = %v, want [nil, timeout, reset] (broken-conn tail must each be recorded, not blamed on cmd0 or dropped)", pe.errs)
+	}
+	if fc.decodeAt != 3 {
+		t.Errorf("decoded %d replies, want 3 (every reply must be decoded, not drained)", fc.decodeAt)
+	}
+}
+
+// A single RESP error fails only its own command; the rest stay successful.
+func TestPipelineErrsRunRecordsSingleRespError(t *testing.T) {
+	wrongtype := errors.New("WRONGTYPE Operation against a key ...")
+	pe := newPE(4)
+	fc := &fakeConn{decodeErrs: []error{nil, wrongtype, nil, nil}}
+
+	pe.Run(fc)
+
+	got := 0
+	for _, e := range pe.errs {
+		if e != nil {
+			got++
+		}
+	}
+	if got != 1 || pe.errs[1] != wrongtype {
+		t.Errorf("errs = %v, want exactly errs[1]=WRONGTYPE (one bad reply must not fail its siblings)", pe.errs)
+	}
+}
+
+// A write failure breaks the connection before any reply, so every command fails.
+func TestPipelineErrsRunEncodeFailureMarksAllFailed(t *testing.T) {
+	boom := errors.New("write tcp: broken pipe")
+	pe := newPE(3)
+	fc := &fakeConn{encodeErr: boom}
+
+	if err := pe.Run(fc); err != boom {
+		t.Errorf("Run returned %v, want %v", err, boom)
+	}
+	for i, e := range pe.errs {
+		if e != boom {
+			t.Errorf("errs[%d] = %v, want %v (a write failure fails the whole batch)", i, e, boom)
+		}
+	}
+	if fc.decodeAt != 0 {
+		t.Errorf("decoded %d replies after an encode failure, want 0", fc.decodeAt)
+	}
+}
+
+// Before Run executes, ran is false and errs is all-nil -- this is the state
+// flushPending detects (via !pe.ran) to attribute a pre-Run client.Do failure
+// (e.g. connection acquisition during an outage) to the whole window instead of
+// silently counting the batch as successful.
+func TestPipelineErrsUnrunHasRanFalseAndNilErrs(t *testing.T) {
+	pe := newPE(5)
+	if pe.ran {
+		t.Error("ran = true before Run, want false")
+	}
+	for i, e := range pe.errs {
+		if e != nil {
+			t.Errorf("errs[%d] = %v before Run, want nil", i, e)
+		}
+	}
+}


### PR DESCRIPTION
Closes #118. (Supersedes #124, which auto-closed when its stacked base branch — #117/#123 — was deleted on merge. #123 is now in master, so this retargets cleanly to master and the diff is just the #118 delta.)

## Problem

`radix.Pipeline.Run` stops decoding at the **first** failing command, **drains** the remaining replies, and returns a single aggregate error for the whole batch. `flushPending` then marked **every** command in the pipeline window as errored — so one bad reply (e.g. a `WRONGTYPE`) in a window of N inflated the error count by up to **N**.

## Fix

Replace `radix.Pipeline` with a small custom `Action` (`pipelineErrs`) that still sends the whole batch in **one buffered write** (`multiMarshal`) but **decodes every reply** and records each command's own error in `errs[i]`. `flushPending` attributes `hadError`/`isTimeout` **per command**.

## Review-gate fixes (from 15 adversarial reviews)

- **Undercount when `client.Do` fails before `Run`:** radix `Pool.Do` calls `pool.get()` before `Action.Run`, so a connection-acquisition failure during an outage returns without ever running `pipelineErrs`, leaving `errs` all-nil → the batch was counted as fully **successful**. Added a `ran` flag; `cmdErr` falls back to the `Do` error for the whole window when `!pe.ran`, and keeps exact per-command attribution once the batch executed.
- **Untested transport-error tail:** added `pipeline_action_test.go` — a fake `radix.Conn` drives `Run` deterministically through a mid-batch i/o-timeout tail, a lone RESP error, an encode failure, and the unrun state.

## Validation

`TestFTSBPipelineErrorCountedPerCommandNotPerWindow`: one `WRONGTYPE` among 9 good `HSET`s in a pipeline of 10 → `Errors == 1` (pre-fix binary: `Errors == 10`, verified). New unit tests + full suite green under `-race`.